### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+## **Reporting a Vulnerability**
+
+We take the security of our projects seriously. If you discover a security vulnerability,
+we appreciate your help in disclosing it to us in a responsible manner.
+
+**Please DO NOT open a public JIRA/GitHub issue.**
+
+Instead, please report the vulnerability directly as described at
+the [Security Contacts and Procedures](https://access.redhat.com/security/team/contact/#contact).
+
+### **Supported Versions**
+
+We provide security fixes for the **latest stable release** of each project.
+To find out which versions match this criteria go to the corresponding project page on [our website](https://hibernate.org/). For example:
+
+* [Hibernate ORM](https://hibernate.org/orm/releases/)
+* [Hibernate Search](https://hibernate.org/search/releases/)
+* [Hibernate Validator](https://hibernate.org/validator/releases/)
+* [Hibernate Reactive](https://hibernate.org/reactive/releases/)
+
+We recommend you use the most recent version to ensure you have the latest security patches and bug fixes.


### PR DESCRIPTION
I've looked at a few projects and drafted this 🫣  
This is one of the "recommended" files to have in a GH repo, and I'm assuming we wouldn't want to create one per each project + maintain the list of versions applicable for patches, so I thought maybe we can point to the website where we already have the info about the versions ?