### PR TITLE
Direct GitHub funding to Commonhaus in FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: commonhaus
+open_collective: commonhaus-foundation


### PR DESCRIPTION
We haven't used GitHub-based funding so far, but apparently Commonhaus does, and we've been asked to do this so the foundation can prosper.

I don't see a problem with it, does anyone?

Note: this only says where the funds will go, we will also need to explicitly enable funding links in repository settings.