### PR TITLE
Align security policy on Commonhaus template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,61 @@
-## **Reporting a Vulnerability**
+# Hibernate Security Policy
 
-We take the security of our projects seriously. If you discover a security vulnerability,
-we appreciate your help in disclosing it to us in a responsible manner.
+This document explains how to report security issues for **Hibernate** projects.
 
-**Please DO NOT open a public JIRA/GitHub issue.**
+## Reporting a Vulnerability
 
-Instead, please report the vulnerability directly as described at
-the [Security Contacts and Procedures](https://access.redhat.com/security/team/contact/#contact).
+Please report suspected security issues privately.
 
-### **Supported Versions**
+- Email **secalert@redhat.com**. Find more details in the [Security Contacts and Procedures](https://access.redhat.com/security/team/contact/#contact).
+- Do **not** open a public JIRA/GitHub issue for suspected vulnerabilities.
 
-We provide security fixes for the **latest stable release** of each project.
-To find out which versions match this criteria go to the corresponding project page on [our website](https://hibernate.org/). For example:
+When reporting, please include:
+
+- A description of the issue and affected project/versions
+- Steps to reproduce (ideally a minimal proof-of-concept)
+- Assessment of potential impact
+- Your contact information
+- Any specific requests, such as anonymity for you and/or the organization you represent
+
+## Maintainer Commitments
+
+We aim to handle reports quickly and responsibly.
+
+- Our goal is to acknowledge reports as soon as possible.
+- We will provide an initial assessment as capacity allows.
+- Progress updates will be shared until resolution.
+- Disclosure will be coordinated with the reporter, and credit given unless anonymity is requested.
+
+## Disclosure and Embargoes
+
+By default, **Hibernate** does **not** accept long embargoes.
+Security reports will usually become public once a fix is available and confirmed.
+A short embargo may be considered in exceptional cases (e.g., downstream user protection), but is not guaranteed.
+
+## Expectations for Reporters
+
+Reporters should understand that:
+
+- This project's security reports are handled by volunteers and Red Hat.
+- Reports with clear steps, proof-of-concept, or test cases help us respond faster.
+- Respecting maintainer capacity and workload benefits the community overall.
+
+## Scope and Versions
+
+This policy applies to the **Hibernate** codebase and related artifacts.
+We currently support security fixes for the **latest stable release** of each project, and select older versions supported by contributing software vendors.
+
+To find out which versions match these criteria, go to the corresponding project page on [the Hibernate website](https://hibernate.org/). For example:
 
 * [Hibernate ORM](https://hibernate.org/orm/releases/)
 * [Hibernate Search](https://hibernate.org/search/releases/)
 * [Hibernate Validator](https://hibernate.org/validator/releases/)
 * [Hibernate Reactive](https://hibernate.org/reactive/releases/)
 
-We recommend you use the most recent version to ensure you have the latest security patches and bug fixes.
+Older versions may not receive patches; in such cases we may advise upgrading.
+
+## Transparency
+
+We may document known security issues or our response status when appropriate.
+This helps users understand our process and sets realistic expectations.
+


### PR DESCRIPTION
This takes inspiration from https://github.com/commonhaus/foundation/pull/276/files#diff-0a7a7539dd9def3ff1ed653a7eaed10fec278487eb904b190dc044b8f4e0c5a1

I didn't not take _everything_ though, and in particular avoided empty promises, because most of the promises we can make are currently listed in the Red Hat secalert docs.
