### PR TITLE
Add auto-updated members.json with a list of Hibernate org members

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "octokit/*"

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -1,0 +1,31 @@
+name: "Update metadata"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 0'
+
+permissions:
+  contents: write
+jobs:
+  update-members:
+    name: "Update members.json"
+    runs-on: ubuntu-latest
+    if: github.repository == 'hibernate/.github'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
+      with:
+        fetch-depth: 1
+    - name: Configure for commits
+      run: |
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'admin@hibernate.org'
+    - run: ./scripts/update-members.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_METADATA_UPDATE }}
+    - name: Push changes if any
+      run: |
+        git add -A
+        git commit -m "Update members.json" || true
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.tmp
+
+# Apple users
+**/.DS_Store
+
+# IDEA users
+*.iml
+.idea
+.project

--- a/members.json
+++ b/members.json
@@ -1,0 +1,14 @@
+[
+  {
+    "login": "sebersole",
+    "avatar_url": "https://avatars.githubusercontent.com/u/234515?v=4",
+    "html_url": "https://github.com/sebersole",
+    "alumnus": false
+  },
+  {
+    "login": "stliu",
+    "avatar_url": "https://avatars.githubusercontent.com/u/174662?v=4",
+    "html_url": "https://github.com/stliu",
+    "alumnus": true
+  }
+]

--- a/scripts/update-members.sh
+++ b/scripts/update-members.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+function rest_api_call() {
+  endpoint=$1
+  shift
+  curl --fail -s -S -L \
+    --variable %GITHUB_TOKEN \
+    -H "Accept: application/vnd.github+json" \
+    --expand-header "Authorization: Bearer {{GITHUB_TOKEN}}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com$endpoint" "${@}"
+}
+
+jq -s 'add | [reduce .[] as $o ({}; .[$o["login"] | tostring] += $o ) | .[]] | sort_by( .login ) | [ .[] | select( .public ) | { login, avatar_url, html_url, "alumnus": (.alumnus // false) } ]' \
+  <( \
+    rest_api_call /orgs/hibernate/teams/alumni/members?per_page=100 \
+      | jq '[.[] + {"alumnus": true}]' \
+  ) \
+  <( \
+    rest_api_call /orgs/hibernate/public_members?per_page=100 \
+      | jq '[.[] + {"public": true}]' \
+  ) \
+  > members.json


### PR DESCRIPTION
This list only includes people and information who can be publicly
fetched through https://api.github.com/orgs/hibernate/public_members,
with the addition of an "alumni: true/false" field extracted from team
membership.

The list is auto-updated by a GitHub Actions job running every week.